### PR TITLE
IPv6 support

### DIFF
--- a/TS3Client/Full/PacketHandler.cs
+++ b/TS3Client/Full/PacketHandler.cs
@@ -125,7 +125,7 @@ namespace TS3Client.Full
 
 				remoteAddress = new IPEndPoint(ipAddr, port);
 
-				udpClient = new UdpClient();
+				udpClient = new UdpClient(remoteAddress.AddressFamily);
 				udpClient.Connect(remoteAddress);
 			}
 			catch (SocketException ex) { throw new Ts3Exception("Could not connect", ex); }


### PR DESCRIPTION
When giving a host name, it gets resolved correctly to either an IPv4 or
IPv6 address. The IPEndPoint contains the correct protocol. The default
[UdpClient constructor](https://docs.microsoft.com/en-us/dotnet/api/system.net.sockets.udpclient.-ctor?view=netframework-4.7) always creates an IPv4 socket. Passing the correct
familiy solves this.