### PR TITLE
Added also "use server port" since it's an actual command.

### DIFF
--- a/TS3Client/Query/Ts3QueryClient.cs
+++ b/TS3Client/Query/Ts3QueryClient.cs
@@ -243,6 +243,10 @@ namespace TS3Client.Query
 			=> Send<ResponseVoid>("use",
 			new CommandParameter("sid", serverId));
 
+		public CmdR UseServerPort(int port)
+			=> Send<ResponseVoid>("use",
+			new CommandParameter("port", port));
+
 		// Splitted base commands
 
 		public override R<ServerGroupAddResponse, CommandError> ServerGroupAdd(string name, GroupType? type = null)


### PR DESCRIPTION
Prior to this modification, there was just UseServer(serverId), in some 'instances' would be more useful to use a direct port. 