### PR TITLE
Remove support for older framework versions

### DIFF
--- a/TS3ABotUnitTests/TS3ABotUnitTests.csproj
+++ b/TS3ABotUnitTests/TS3ABotUnitTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netcoreapp2.2;net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
 
     <LangVersion>7.3</LangVersion>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/TS3AudioBot/TS3AudioBot.csproj
+++ b/TS3AudioBot/TS3AudioBot.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;netcoreapp2.2;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2;netstandard2.0</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <RootNamespace>TS3AudioBot</RootNamespace>
     <AssemblyName>TS3AudioBot</AssemblyName>

--- a/TS3Client/TS3Client.csproj
+++ b/TS3Client/TS3Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net472;netcoreapp2.2;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2;netstandard2.0</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <RootNamespace>TS3Client</RootNamespace>
     <AssemblyName>TS3Client</AssemblyName>


### PR DESCRIPTION
Yes,

I do not know your bot very well, but I can't understand why you should support an old framework version?

If we drop it, it would allow me to compile it on linux as well. A big deal for me.

"On my machine it compiles"... :p   of course you need the .net core sdk. However, I did not test your bot with this change.

I would be happy to hear from you if you can't make this happen.