### PR TITLE
Fix query client connection fails with IPv6

### DIFF
--- a/TS3Client/Query/Ts3QueryClient.cs
+++ b/TS3Client/Query/Ts3QueryClient.cs
@@ -63,12 +63,6 @@ namespace TS3Client.Query
 			{
 				connecting = true;
 
-				// Create a new client instance using the correct address family,
-				// because it can't be adjusted after the underlying socket was
-				// created by TcpClient (default is IPv4, but come on, it's 2020).
-				// This prevents failing connections due to the address family
-				// of the socket not matching the address family of the given
-				// remote address when using IPv6.
 				tcpClient = new TcpClient(remoteAddress.AddressFamily);
 				tcpClient.Connect(remoteAddress);
 


### PR DESCRIPTION
The default constructor of `TcpClient` initializes a socket with the `InterNetwork` (IPv4) address family. Trying to connect using an IPv6 address then results in an exception. The [documentation of the `TcpClient` default constructor](https://docs.microsoft.com/en-us/dotnet/api/system.net.sockets.tcpclient.-ctor#System_Net_Sockets_TcpClient__ctor) states that:

> This constructor works only with IPv4 address types.

To fix that, the client is created right before connecting, passing the address family of the `remoteAddress` to the constructor.