### PR TITLE
Add delay to wait until YouTube resource is ready to be played

### DIFF
--- a/TS3AudioBot/ResourceFactories/Youtube/YoutubeResolver.cs
+++ b/TS3AudioBot/ResourceFactories/Youtube/YoutubeResolver.cs
@@ -160,6 +160,19 @@ public sealed partial class YoutubeResolver : IResourceResolver, IPlaylistResolv
 			throw Error.LocalStr(strings.error_ytdl_empty_response);
 
 		Log.Debug("youtube-dl succeeded!");
+
+		if (format!.available_at.HasValue)
+		{
+			var availableTime = Tools.FromUnix(format.available_at.Value);
+			var waitTime = availableTime - DateTime.UtcNow;
+
+			if (waitTime > TimeSpan.Zero)
+			{
+				Log.Debug($"Waiting youtube delay: {waitTime}");
+				await Task.Delay(waitTime, cancellationToken);
+			}
+		}
+
 		return new PlayResource(url, resource, songInfo: songInfo);
 	}
 

--- a/TS3AudioBot/ResourceFactories/YoutubeDlHelper.cs
+++ b/TS3AudioBot/ResourceFactories/YoutubeDlHelper.cs
@@ -320,6 +320,7 @@ public class JsonYtdlFormat
 	public string? format_id { get; set; }
 	public string? url { get; set; }
 	public string? ext { get; set; }
+	public uint? available_at { get; set; }
 }
 
 public class JsonYtdlPlaylistDump : JsonYtdlBase


### PR DESCRIPTION
For a while now I have noticed that some YouTube links could not be played.

After some debugging I noticed that the started ffmpeg process exited with the error:
`Error opening input files: Server returned 403 Forbidden (access denied)`
But when testing the same command extracted from logs manually it always worked without a problem.

After some searching I found out that at least yt-dlp contains a `available_at` timestamp that matches the _new_ delay YouTube makes us wait before a video starts.
Parsing and waiting for that delay has fixed playback for me.

I'm not entirely sure if this is the best location for the check.. but moving it somewhere else would require more refactoring.